### PR TITLE
CORE-8013 -- Fix calculating the age for particular field

### DIFF
--- a/Sources/Apollo/GraphQLFirstReceivedAtTracker.swift
+++ b/Sources/Apollo/GraphQLFirstReceivedAtTracker.swift
@@ -1,24 +1,36 @@
 import Foundation
 
+/*
+ This accumulator uses max and distantPast for comparisons of the first received date.
+
+ The primary purpose of the date is the *oldest* age of data in a given object graph.
+
+ It is responsible for providing a default value when dealing with data for the first time, so `oldestDate` is used.
+
+ However, once a date has been established it needs to compare against the previous age established - which is `distantPast`.
+
+ So we compare dates using `max()`.
+ */
+
 final class GraphQLFirstReceivedAtTracker: GraphQLResultAccumulator {
-  func accept(scalar: JSONValue, firstReceivedAt: Date, info: GraphQLResolveInfo) throws -> Date {
+  func accept(scalar: JSONValue, firstReceivedAt: Date, info: GraphQLResolveInfo) throws -> Date? {
     return firstReceivedAt
   }
 
-  func acceptNullValue(firstReceivedAt: Date, info: GraphQLResolveInfo) throws -> Date {
+  func acceptNullValue(firstReceivedAt: Date, info: GraphQLResolveInfo) throws -> Date? {
     return firstReceivedAt
   }
 
-  func accept(list: [Date], info: GraphQLResolveInfo) throws -> Date {
-    return list.min() ?? .distantPast
+  func accept(list: [Date?], info: GraphQLResolveInfo) throws -> Date? {
+    return list.compactMap({ $0 }).max()
   }
 
-  func accept(fieldEntry: Date, info: GraphQLResolveInfo) throws -> Date {
-    return fieldEntry
+  func accept(fieldEntry: Date?, info: GraphQLResolveInfo) throws -> Date {
+    return fieldEntry ?? .distantPast
   }
 
   func accept(fieldEntries: [Date], info: GraphQLResolveInfo) throws -> Date {
-    return fieldEntries.min() ?? .distantPast
+    return fieldEntries.max() ?? .distantPast
   }
 
   func finish(rootValue: Date, info: GraphQLResolveInfo) throws -> GraphQLResultMetadata {


### PR DESCRIPTION
The root cause issue is that this reducer is trying to compare two values and since we're using the default `distantPast` (which is correct, as we want data to "age") but when we actually want to compare a value we have (such as when we're updating the cache) we need to correctly determine what is the _newest_ date - hence the use of `max` instead.