### PR TITLE
PIL-15 -- Add cache fallback policy on error from the old fork

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -16,6 +16,8 @@ public enum CachePolicy: Hashable {
   case returnCacheDataDontFetch
   /// Return data from the cache if available, and always fetch results from the server.
   case returnCacheDataAndFetch
+  /// Attempt to fetch from the server, using cache data if available on error
+  case fetchReturningCacheDataOnError
   
   /// The current default cache policy.
   public static var `default`: CachePolicy = .returnCacheDataElseFetch

--- a/Sources/Apollo/CacheReadInterceptor.swift
+++ b/Sources/Apollo/CacheReadInterceptor.swift
@@ -100,3 +100,9 @@ public struct CacheReadInterceptor: ApolloInterceptor {
       }
     }
 }
+
+extension HTTPRequest {
+   fileprivate func clone(withPolicy policy: CachePolicy) -> HTTPRequest {
+     return .init(self, cachePolicy: policy)
+   }
+ }

--- a/Sources/Apollo/HTTPRequest.swift
+++ b/Sources/Apollo/HTTPRequest.swift
@@ -65,6 +65,14 @@ open class HTTPRequest<Operation: GraphQLOperation>: Hashable {
     self.addHeader(name: "apollographql-client-version", value: clientVersion)
     self.addHeader(name: "apollographql-client-name", value: clientName)
   }
+
+  internal init(_ original: HTTPRequest<Operation>, cachePolicy: CachePolicy) {
+    self.graphQLEndpoint = original.graphQLEndpoint
+    self.operation = original.operation
+    self.contextIdentifier = original.contextIdentifier
+    self.additionalHeaders = original.additionalHeaders
+    self.cachePolicy = cachePolicy
+  }
   
   open func addHeader(name: String, value: String) {
     self.additionalHeaders[name] = value

--- a/Tests/ApolloTests/Cache/FetchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/FetchQueryTests.swift
@@ -259,8 +259,6 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   }
 
   func testFetchReturningCacheDataOnErrorReturnsData() throws {
-    struct TestError: Error { }
-
     class HeroNameSelectionSet: MockSelectionSet {
       override class var __selections: [Selection] { [
         .field("hero", Hero.self)

--- a/Tests/ApolloTests/Cache/FetchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/FetchQueryTests.swift
@@ -257,6 +257,58 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
     
     wait(for: [serverRequestExpectation, fetchResultFromServerExpectation], timeout: Self.defaultWaitTimeout)
   }
+
+  func testFetchReturningCacheDataOnErrorReturnsData() throws {
+    struct TestError: Error { }
+
+    class HeroNameSelectionSet: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let query = MockQuery<HeroNameSelectionSet>()
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid"
+      ]
+    ])
+
+    let serverRequestExpectation =
+      server.expect(MockQuery<HeroNameSelectionSet>.self) { request in
+      [
+        "data": [
+          "hero": [] // incomplete data will cause an error on fetch
+        ]
+      ]
+    }
+
+    let resultObserver = makeResultObserver(for: query)
+
+    let fetchResultFromServerExpectation = resultObserver.expectation(description: "Received result from cache") { result in
+      try XCTAssertSuccessResult(result) { graphQLResult in
+        XCTAssertEqual(graphQLResult.source, .cache)
+        XCTAssertNil(graphQLResult.errors)
+
+        let data = try XCTUnwrap(graphQLResult.data)
+        XCTAssertEqual(data.hero?.name, "R2-D2")
+      }
+    }
+
+    client.fetch(query: query, cachePolicy: .fetchReturningCacheDataOnError, resultHandler: resultObserver.handler)
+
+    wait(for: [serverRequestExpectation, fetchResultFromServerExpectation], timeout: Self.defaultWaitTimeout)
+  }
   
   func test__fetch__givenCachePolicy_returnCacheDataDontFetch_givenDataIsCached_doesntHitNetwork() throws {
     class HeroNameSelectionSet: MockSelectionSet {


### PR DESCRIPTION
## Summary

- Add cache fallback policy on error based on the legacy fork changes. See #5 for reference.
- Refactor the unit test to be aligned with the modern apollo-ios code  

| Server failing - falling back to cache | Server succeeding - fails to fallback to cached data |
|---|---|
| ![Passing](https://user-images.githubusercontent.com/6117280/214740897-e3f911b5-15af-4f89-9f8c-5248c27c6e8a.png)  | ![Failing](https://user-images.githubusercontent.com/6117280/214740919-99c431bf-4fef-4009-b21c-9f7d1cc1ba52.png)
| If the mocked result from the server fails, then the tests succeed  | If we run the same test with a valid response from the server, then the test fails (expected)

