### PR TITLE
remove metadata from GraphQL result

### DIFF
--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -10,7 +10,7 @@ import Foundation
    public let maxAge: Date
    public let id = UUID()
 
-   init(maxAge: Date = Date()) {
+   public init(maxAge: Date = Date()) {
      self.maxAge = maxAge
    }
  }


### PR DESCRIPTION
- remove `metadata` property from `GraphQLResult` I can't mock result because this property and this is also not needed when we switch to mainline Apollo